### PR TITLE
sync-redcap-to-commcare script

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This repo is for an assortment of scripts for developers working with Commcare.
       - [The workflow](#the-workflow)
       - [Creating the data dict](#creating-the-data-dict)
       - [Running the script](#running-the-script)
+    - [`sync-redcap-to-commcare`](#sync-commcare-app-to-db)
   - [Logging](#logging)
 
 ## Setup

--- a/README.md
+++ b/README.md
@@ -218,6 +218,52 @@ bulk-upload-legacy-contact-data --username $COMMCARE_USER --apikey $COMMCARE_API
 
 Note that the `--contactKeyValDict` is an optional argument. Any key-value pairs provided for this option will be added to all contacts created by the script.
 
+### `sync-redcap-to-commcare`
+
+This script is intended to sync case and contact data from a REDCap project to a corresponding CommCare contact tracing application. It assumes that:
+
+* the project includes `redcap_repeat_instrument` called `"close_contacts"`
+* checkbox fields are separated by a triple underscore (`___`) and the part after the triple underscore should be placed in a space-separated string property in CommCare (see `collapse_checkbox_columns()`)
+* the column names in REDCap should otherwise be copied as-is to CommCare
+
+To use the script, see its `--help` output:
+
+```
+sync-redcap-to-commcare --help
+usage: sync-redcap-to-commcare [-h] --username COMMCARE_USER_NAME --apikey
+                               COMMCARE_API_KEY --project
+                               COMMCARE_PROJECT_NAME --redcap-api-url
+                               REDCAP_API_URL --redcap-api-key REDCAP_API_KEY
+                               --external-id-col EXTERNAL_ID_COL --state-file
+                               STATE_FILE [--sync-all]
+
+optional arguments:
+  -h, --help            show this help message and exit
+  --username COMMCARE_USER_NAME
+                        The Commcare username (email address)
+  --apikey COMMCARE_API_KEY
+                        A Commcare API key
+  --project COMMCARE_PROJECT_NAME
+                        The Commcare project name
+  --redcap-api-url REDCAP_API_URL
+                        The REDCap API URL
+  --redcap-api-key REDCAP_API_KEY
+                        A REDCap API key
+  --external-id-col EXTERNAL_ID_COL
+                        Name of column in REDCap that should be used as the
+                        external_id in CommCare
+  --state-file STATE_FILE
+                        The path where state should be read and saved
+  --sync-all            If set, ignore the begin date in the state file and
+                        sync all records
+```
+
+Sample command:
+
+```
+sync-redcap-to-commcare --username=$COMMCARE_USERNAME --apikey=$COMMCARE_API_KEY --project=$COMMCARE_PROJECT --redcap-api-url=$REDCAP_API_URL --redcap-api-key=$REDCAP_API_KEY --external-id-col=our_mrs_id --state-file=redcap_test.yaml --sync-all
+```
+
 ## Logging
 
 By default, this package logs to a .gitignored log file at `logs/cc-utilities.log`. This file is limited to 5MB and beyond that size, the log will be rotated. To log to a non-default location, you can set an env var for `COMMCARE_UTILITIES_LOG_PATH` for a directory in which to save logs.

--- a/README.md
+++ b/README.md
@@ -261,8 +261,16 @@ optional arguments:
 
 Sample command:
 
-```
-sync-redcap-to-commcare --username=$COMMCARE_USERNAME --apikey=$COMMCARE_API_KEY --project=$COMMCARE_PROJECT --redcap-api-url=$REDCAP_API_URL --redcap-api-key=$REDCAP_API_KEY --external-id-col=our_mrs_id --state-file=redcap_test.yaml --sync-all
+```linux
+sync-redcap-to-commcare \
+  --username=$COMMCARE_USERNAME \
+  --apikey=$COMMCARE_API_KEY \
+  --project=$COMMCARE_PROJECT \
+  --redcap-api-url=$REDCAP_API_URL \
+  --redcap-api-key=$REDCAP_API_KEY \
+  --external-id-col=our_mrs_id \
+  --state-file=redcap_test.yaml \
+  --sync-all
 ```
 
 ## Logging

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This repo is for an assortment of scripts for developers working with Commcare.
       - [The workflow](#the-workflow)
       - [Creating the data dict](#creating-the-data-dict)
       - [Running the script](#running-the-script)
-    - [`sync-redcap-to-commcare`](#sync-commcare-app-to-db)
+    - [`sync-redcap-to-commcare`](#sync-redcap-to-commcare)
   - [Logging](#logging)
 
 ## Setup

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -61,7 +61,7 @@ def main_with_args(
             # Without index_col=False, read_csv() will use the first column
             # ("record_id") as the index, which is problematic because it's
             # not unique and is easier to handle as a separate column anyways.
-            df_kwargs={"index_col": False},
+            df_kwargs={"index_col": False, "dtype": str},
         )
         .pipe(collapse_checkbox_columns)
         .pipe(split_cases_and_contacts)

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -71,13 +71,14 @@ def main_with_args(
         logger.info("Retrieving and cleaning data from REDCap...")
         redcap_project = redcap.Project(redcap_api_url, redcap_api_key)
         redcap_records = redcap_project.export_records(
-            format="df",
             # date_begin corresponds to the dateRangeBegin field in the REDCap
             # API, which "return[s] only records that have been created or modified
             # *after* a given date/time." Note that REDCap expects this to be in
             # server time, so the script and server should be run in the same time
             # zone (or this script modified to accept a timezone argument).
             date_begin=state["date_begin"] if not sync_all else None,
+            # Tell PyCap to return a pandas DataFrame.
+            format="df",
             df_kwargs={
                 # Without index_col=False, read_csv() will use the first column
                 # ("record_id") as the index, which is problematic because it's

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -6,6 +6,12 @@ import redcap
 import yaml
 
 from cc_utilities.logger import logger
+from cc_utilities.redcap_sync import clean_redcap_data
+
+EXCLUDE_COLUMNS = [
+    "redcap_repeat_instrument",
+    "redcap_repeat_instance",
+]
 
 
 def get_state(state_file):
@@ -50,7 +56,8 @@ def main_with_args(
     redcap_project = redcap.Project(redcap_api_url, redcap_api_key)
     next_date_begin = datetime.now()
 
-    redcap_project.export_records(format="df", date_begin=state["date_begin"])
+    df = redcap_project.export_records(format="df", date_begin=state["date_begin"])
+    clean_redcap_data(df)
 
     state["date_begin"] = next_date_begin
     save_state(state, state_file)
@@ -88,7 +95,7 @@ def main():
     )
     parser.add_argument(
         "--state-file",
-        help="The path where state should be read and daved",
+        help="The path where state should be read and saved",
         dest="state_file",
         required=True,
     )

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -1,0 +1,109 @@
+import argparse
+import os
+from datetime import datetime
+
+import redcap
+import yaml
+
+from cc_utilities.logger import logger
+
+
+def get_state(state_file):
+    "Read state required for REDCap sync."
+    if not os.path.exists(state_file):
+        return {
+            "date_begin": None,
+        }
+    with open(state_file) as f:
+        return yaml.safe_load(f)
+
+
+def save_state(state, state_file):
+    "Save state required for REDCap sync."
+    with open(state_file, "w") as f:
+        yaml.dump(state, f)
+
+
+def main_with_args(
+    commcare_user_name,
+    commcare_api_key,
+    commcare_project_name,
+    redcap_api_url,
+    redcap_api_key,
+    state_file,
+    data_dictionary_path,
+):
+    """TBD
+
+
+    Args:
+        commcare_user_name (str): The Commcare username (email address)
+        commcare_api_key (str): A Commcare API key for the user
+        commcare_project_name (str): The Commcare project to which contacts will be imported
+        redcap_api_url (str): The URL to the REDCap API server
+        redcap_api_key (str): The REDCap API key
+        state_file (str): File path to a local file where state about this sync can be kept
+        data_dictionary_path (str): The path to the Commcare data dictionary (optional)
+    """
+
+    state = get_state(state_file)
+    redcap_project = redcap.Project(redcap_api_url, redcap_api_key)
+    next_date_begin = datetime.now()
+
+    redcap_project.export_records(format="df", date_begin=state["date_begin"])
+
+    state["date_begin"] = next_date_begin
+    save_state(state, state_file)
+    logger.info("Sync done.")
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--username",
+        help="The Commcare username (email address)",
+        dest="commcare_user_name",
+        required=True,
+    )
+    parser.add_argument(
+        "--apikey", help="A Commcare API key", dest="commcare_api_key", required=True,
+    )
+    parser.add_argument(
+        "--project",
+        help="The Commcare project name",
+        dest="commcare_project_name",
+        required=True,
+    )
+    parser.add_argument(
+        "--redcap-api-url",
+        help="The REDCap API URL",
+        dest="redcap_api_url",
+        required=True,
+    )
+    parser.add_argument(
+        "--redcap-api-key",
+        help="A REDCap API key",
+        dest="redcap_api_key",
+        required=True,
+    )
+    parser.add_argument(
+        "--state-file",
+        help="The path where state should be read and daved",
+        dest="state_file",
+        required=True,
+    )
+    parser.add_argument(
+        "--data-dict-path",
+        help="The path where the data dictionary CSV is located, for validation purposes (optional)",
+        dest="data_dictionary_path",
+    )
+    args = parser.parse_args()
+    main_with_args(
+        args.commcare_user_name,
+        args.commcare_api_key,
+        args.commcare_project_name,
+        args.redcap_api_url,
+        args.redcap_api_key,
+        args.state_file,
+        args.data_dictionary_path,
+    )

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -78,10 +78,16 @@ def main_with_args(
             # server time, so the script and server should be run in the same time
             # zone (or this script modified to accept a timezone argument).
             date_begin=state["date_begin"] if not sync_all else None,
-            # Without index_col=False, read_csv() will use the first column
-            # ("record_id") as the index, which is problematic because it's
-            # not unique and is easier to handle as a separate column anyways.
-            df_kwargs={"index_col": False, "dtype": str},
+            df_kwargs={
+                # Without index_col=False, read_csv() will use the first column
+                # ("record_id") as the index, which is problematic because it's
+                # not unique and is easier to handle as a separate column anyways.
+                "index_col": False,
+                # We import everything as a string, to avoid pandas coercing ints
+                # to floats and adding unnecessary decimal points in the data when
+                # uploaded to CommCare.
+                "dtype": str,
+            },
         )
         if len(redcap_records.index) == 0:
             logger.info("No records returned from REDCap; aborting sync.")

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -66,7 +66,7 @@ def main_with_args(
         .pipe(collapse_checkbox_columns)
         .pipe(split_cases_and_contacts)
     )
-    logger.info("Uploading found patients (case) to CommCare...")
+    logger.info("Uploading found patients (cases) to CommCare...")
     upload_data_to_commcare(
         cases_df,
         commcare_project_name,

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -35,11 +35,12 @@ def main_with_args(
     redcap_api_key,
     external_id_col,
     state_file,
-    data_dict_path,
     sync_all,
 ):
-    """TBD
-
+    """
+    Script to download case and contact records for the given `redcap_api_url` and
+    `redcap_api_key` and upload them to the provided `commcare_project_name` via
+    CommCare's bulk upload API.
 
     Args:
         commcare_user_name (str): The Commcare username (email address)
@@ -49,7 +50,6 @@ def main_with_args(
         redcap_api_key (str): The REDCap API key
         external_id_col (str): The name of the column in REDCap that contains the external_id for CommCare
         state_file (str): File path to a local file where state about this sync can be kept
-        data_dict_path (str): The path to the Commcare data dictionary (optional)
         sync_all (bool): If set, ignore the date_begin in the state_file and sync all records
     """
 
@@ -155,10 +155,6 @@ def main():
         required=True,
     )
     parser.add_argument(
-        "--data-dict-path",
-        help="The path where the data dictionary CSV is located, for validation purposes (optional)",
-    )
-    parser.add_argument(
         "--sync-all",
         help="If set, ignore the begin date in the state file and sync all records",
         action="store_true",
@@ -172,6 +168,5 @@ def main():
         args.redcap_api_key,
         args.external_id_col,
         args.state_file,
-        args.data_dict_path,
         args.sync_all,
     )

--- a/cc_utilities/common.py
+++ b/cc_utilities/common.py
@@ -137,7 +137,7 @@ def get_commcare_cases(
 
 
 def upload_data_to_commcare(
-    data,
+    df,  # can be dict or pd.DataFrame
     project_slug,
     case_type,
     search_column,
@@ -156,11 +156,11 @@ def upload_data_to_commcare(
     }
     adapter = HTTPAdapter(max_retries=retry_strategy)
     url = BULK_UPLOAD_URL.format(project_slug)
-    fieldnames = data[0].keys()
+    if not isinstance(df, pd.DataFrame):
+        df = pd.DataFrame(df)
     assert (
-        search_column in fieldnames
+        search_column in df.columns
     ), f"Data items must have property '{search_column}'"
-    df = pd.DataFrame(data)
     files = {
         "file": (
             f"{file_name_prefix}{case_type}.csv",

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -1,0 +1,34 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+def collapse_checkbox_columns(df):
+    """
+    Converts REDCap-style checkbox columns ("box1___yellow", "box1___green") to CommCare-style
+    checkbox files ("box1": "yellow green"). See test for details.
+    """
+    df = df.copy()
+    for redcap_col in [col for col in df.columns if "___" in col]:
+        cc_property, cc_value = redcap_col.split("___", 1)
+        if cc_property not in df.columns:
+            logger.info(f"Adding column {cc_property} to df")
+            df[cc_property] = ""
+        # Covert NaN/0/1 in REDCap to space-separated string values for CommCare
+        df[cc_property] = df[cc_property].combine(
+            df[redcap_col].fillna(0),
+            lambda existing_cc_value, redcap_is_set: " ".join(
+                filter(bool, [existing_cc_value, cc_value if redcap_is_set else ""])
+            ),
+        )
+        logger.info(f"Dropping column {redcap_col} from df")
+        df.drop(columns=redcap_col, inplace=True)
+    return df
+
+
+def clean_redcap_data(df):
+    """
+    Cleans a dataframe from REDCap to be suitable for import to CommCare.
+    """
+    df = collapse_checkbox_columns(df)
+    return df

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -79,6 +79,6 @@ def split_cases_and_contacts(df):
         lambda row: f"REDCAP-{row['record_id']}-{row['redcap_repeat_instance']}", axis=1
     )
     contacts_df.drop(
-        ["redcap_repeat_instrument", "redcap_repeat_instance"], axis=1, inplace=True
+        columns=["redcap_repeat_instrument", "redcap_repeat_instance"], inplace=True
     )
     return cases_df, contacts_df

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -22,7 +22,7 @@ def collapse_checkbox_columns(df):
         logger.info(f"Adding column {cc_property} to df")
         df[cc_property] = df.apply(
             lambda row: " ".join(
-                # If REDCap value is not NaN or None and is truthy, return cc_value,
+                # If REDCap value is equal to "1", return cc_value,
                 # else return False (to be filtered out by filter()).
                 filter(
                     bool,

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -1,4 +1,7 @@
 import logging
+from collections import defaultdict
+
+import pandas as pd
 
 logger = logging.getLogger(__name__)
 
@@ -9,26 +12,73 @@ def collapse_checkbox_columns(df):
     checkbox files ("box1": "yellow green"). See test for details.
     """
     df = df.copy()
+    # First, collect the columns that need to be collapsed, in case they don't
+    # all appear together.
+    cc_properties = defaultdict(list)
     for redcap_col in [col for col in df.columns if "___" in col]:
         cc_property, cc_value = redcap_col.split("___", 1)
-        if cc_property not in df.columns:
-            logger.info(f"Adding column {cc_property} to df")
-            df[cc_property] = ""
-        # Covert NaN/0/1 in REDCap to space-separated string values for CommCare
-        df[cc_property] = df[cc_property].combine(
-            df[redcap_col].fillna(0),
-            lambda existing_cc_value, redcap_is_set: " ".join(
-                filter(bool, [existing_cc_value, cc_value if redcap_is_set else ""])
+        cc_properties[cc_property].append((redcap_col, cc_value))
+    # Add new column with the checkbox values collapsed into a single column
+    for cc_property, source_val_list in cc_properties.items():
+        logger.info(f"Adding column {cc_property} to df")
+        df[cc_property] = df.apply(
+            lambda row: " ".join(
+                # If REDCap value is not NaN or None and is truthy, return cc_value,
+                # else return False (to be filtered out by filter()).
+                filter(
+                    bool,
+                    [
+                        cc_value
+                        if pd.notnull(row[redcap_col]) and row[redcap_col]
+                        else False
+                        for redcap_col, cc_value in source_val_list
+                    ],
+                )
             ),
+            axis=1,
         )
-        logger.info(f"Dropping column {redcap_col} from df")
-        df.drop(columns=redcap_col, inplace=True)
+        # Remove the obsolete columns
+        for redcap_col, _ in source_val_list:
+            logger.info(f"Dropping column {redcap_col} from df")
+            df.drop(columns=redcap_col, inplace=True)
     return df
 
 
-def clean_redcap_data(df):
+def split_cases_and_contacts(df):
     """
-    Cleans a dataframe from REDCap to be suitable for import to CommCare.
+    Splits a single dataframe of cases and contacts in two, based on the values in the
+    "redcap_repeat_instrument" column, and assigns the columns necessary for import
+    to CommCare.
     """
-    df = collapse_checkbox_columns(df)
-    return df
+    # Rows with null value in "redcap_repeat_instrument" column and columns that contain
+    # only missing values removed.
+    cases_df = df.loc[df["redcap_repeat_instrument"].isnull()].dropna(axis=1, how="all")
+    if "cdms_id" in cases_df.columns:
+        cases_df["external_id"] = cases_df["cdms_id"]
+    else:
+        # No cdms_id column added in REDCap yet; generate one for testing purposes.
+        logger.warning(
+            "Using REDCap record_id for external_id! Future uploads may duplicate cases."
+        )
+        cases_df["external_id"] = cases_df.apply(
+            lambda row: f"REDCAP-{row['record_id']}", axis=1
+        )
+    # Rows with "close_contacts" in "redcap_repeat_instrument" column and columns that
+    # contain only missing values removed.
+    contacts_df = df.loc[df["redcap_repeat_instrument"] == "close_contacts"].dropna(
+        axis=1, how="all"
+    )
+    contacts_df["parent_type"] = "patient"
+    contacts_df["parent_external_id"] = contacts_df.apply(
+        lambda row: cases_df.loc[
+            cases_df["record_id"] == row["record_id"], "external_id"
+        ].values[0],
+        axis=1,
+    )
+    contacts_df["external_id"] = contacts_df.apply(
+        lambda row: f"REDCAP-{row['record_id']}-{row['redcap_repeat_instance']}", axis=1
+    )
+    contacts_df.drop(
+        ["redcap_repeat_instrument", "redcap_repeat_instance"], axis=1, inplace=True
+    )
+    return cases_df, contacts_df

--- a/setup.py
+++ b/setup.py
@@ -18,8 +18,7 @@ setup(
         "SQLAlchemy",
         "phonenumbers",
         "pandas",
-        # FIXME: Add "pycap==1.1.2" once this version is released; see: https://github.com/redcap-tools/PyCap/issues/126
-        # In the meantime, you can pip install https://github.com/redcap-tools/PyCap/archive/master.zip
+        "pycap==1.1.2",  # REDCap API
         "numpy",
         "xlrd",
     ],

--- a/setup.py
+++ b/setup.py
@@ -5,8 +5,8 @@ setup(
     version="1.0.0",
     description="Helpful utilities for working with CommCare",
     url="https://github.com/caktus/commcare-utilities",
-    author="Benjamin White",
-    author_email="pypy@benjamineugenewhite.com",
+    author="Caktus Consulting Group, LLC",
+    author_email="team@caktusgroup.com",
     license="MIT",
     packages=["cc_utilities", "cc_utilities.command_line"],
     install_requires=[
@@ -18,6 +18,8 @@ setup(
         "SQLAlchemy",
         "phonenumbers",
         "pandas",
+        # FIXME: Add "pycap==1.1.2" once this version is released; see: https://github.com/redcap-tools/PyCap/issues/126
+        # In the meantime, you can pip install https://github.com/redcap-tools/PyCap/archive/master.zip
         "numpy",
         "xlrd",
     ],
@@ -27,6 +29,7 @@ setup(
             "generate-case-export-query-file=cc_utilities.command_line.generate_case_export_query_file:main",
             "bulk-upload-legacy-contact-data=cc_utilities.command_line.bulk_upload_legacy_contact_data:main",
             "sync-commcare-app-to-db=cc_utilities.command_line.sync_commcare_app_to_db:main",
+            "sync-redcap-to-commcare=cc_utilities.command_line.sync_redcap_to_commcare:main",
         ]
     },
     zip_safe=False,

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -1,6 +1,7 @@
+import numpy as np
 import pandas as pd
 
-from cc_utilities.redcap_sync import collapse_checkbox_columns
+from cc_utilities.redcap_sync import collapse_checkbox_columns, split_cases_and_contacts
 
 
 def test_collapse_checkbox_columns():
@@ -21,3 +22,93 @@ def test_collapse_checkbox_columns():
     )
     new_df = collapse_checkbox_columns(df)
     pd.testing.assert_frame_equal(expected_df, new_df)
+
+
+def test_split_cases_and_contacts():
+    df = pd.DataFrame(
+        {
+            "record_id": [1, 2, 2, 3, 3],
+            "redcap_repeat_instrument": [
+                None,
+                None,
+                "close_contacts",
+                np.nan,
+                "close_contacts",
+            ],
+            "redcap_repeat_instance": pd.array([None, None, 1, None, 1], dtype="Int64"),
+            # Int64 (capital I) is the nullable integer type:
+            # https://pandas.pydata.org/pandas-docs/stable/user_guide/integer_na.html
+            "cdms_id": pd.array([1234, 1234, None, 1234, None], dtype="Int64"),
+            "arbitrary": ["some", "arbitrary", "values", 2, "test"],
+            "empty_col": [None, None, None, np.nan, np.nan],
+        },
+        index=[1, 2, 3, 4, 5],
+    )
+    expected_cases_df = pd.DataFrame(
+        {
+            "record_id": [1, 2, 3],
+            "cdms_id": pd.array([1234, 1234, 1234], dtype="Int64"),
+            "arbitrary": ["some", "arbitrary", 2],
+            "external_id": pd.array([1234, 1234, 1234], dtype="Int64"),
+        },
+        index=[1, 2, 4],
+    )
+    expected_contacts_df = pd.DataFrame(
+        {
+            "record_id": [2, 3],
+            "arbitrary": ["values", "test"],
+            "parent_type": ["patient", "patient"],
+            "parent_external_id": [1234, 1234],
+            "external_id": ["REDCAP-2-1", "REDCAP-3-1"],
+        },
+        index=[3, 5],
+    )
+    cases_df, contacts_df = split_cases_and_contacts(df)
+    pd.testing.assert_frame_equal(expected_cases_df, cases_df)
+    pd.testing.assert_frame_equal(
+        expected_contacts_df, contacts_df, check_index_type=False
+    )
+
+
+def test_split_cases_and_contacts_no_cdms_id():
+    df = pd.DataFrame(
+        {
+            "record_id": [1, 2, 2, 3, 3],
+            "redcap_repeat_instrument": [
+                None,
+                None,
+                "close_contacts",
+                np.nan,
+                "close_contacts",
+            ],
+            "redcap_repeat_instance": pd.array([None, None, 1, None, 1], dtype="Int64"),
+            # cdms_id missing
+            "arbitrary": ["some", "arbitrary", "values", 2, "test"],
+            "empty_col": [None, None, None, np.nan, np.nan],
+        },
+        index=[1, 2, 3, 4, 5],
+    )
+    expected_cases_df = pd.DataFrame(
+        {
+            "record_id": [1, 2, 3],
+            # cdms_id missing
+            "arbitrary": ["some", "arbitrary", 2],
+            "external_id": ["REDCAP-1", "REDCAP-2", "REDCAP-3"],
+        },
+        index=[1, 2, 4],
+    )
+    expected_contacts_df = pd.DataFrame(
+        {
+            "record_id": [2, 3],
+            "arbitrary": ["values", "test"],
+            "parent_type": ["patient", "patient"],
+            "parent_external_id": ["REDCAP-2", "REDCAP-3"],
+            "external_id": ["REDCAP-2-1", "REDCAP-3-1"],
+        },
+        index=[3, 5],
+    )
+    cases_df, contacts_df = split_cases_and_contacts(df)
+    pd.testing.assert_frame_equal(expected_cases_df, cases_df)
+    pd.testing.assert_frame_equal(
+        expected_contacts_df, contacts_df, check_index_type=False
+    )

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -1,0 +1,23 @@
+import pandas as pd
+
+from cc_utilities.redcap_sync import collapse_checkbox_columns
+
+
+def test_collapse_checkbox_columns():
+    df = pd.DataFrame(
+        {
+            "box1___yellow": [1, None, 1],
+            "box1___green": [None, 1, 1],
+            "box1___blue": [None, None, None],
+            "box1___other": [1, None, None],
+            "box1__other": ["test", "", ""],
+        }
+    )
+    expected_df = pd.DataFrame(
+        {
+            "box1__other": ["test", "", ""],
+            "box1": ["yellow other", "green", "yellow green"],
+        }
+    )
+    new_df = collapse_checkbox_columns(df)
+    pd.testing.assert_frame_equal(expected_df, new_df)

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -7,10 +7,10 @@ from cc_utilities.redcap_sync import collapse_checkbox_columns, split_cases_and_
 def test_collapse_checkbox_columns():
     df = pd.DataFrame(
         {
-            "box1___yellow": [1, None, 1],
-            "box1___green": [None, 1, 1],
-            "box1___blue": [None, None, None],
-            "box1___other": [1, None, None],
+            "box1___yellow": ["1", "0", "1"],
+            "box1___green": [None, "1", "1"],
+            "box1___blue": [None, "0", None],
+            "box1___other": ["1", None, "0"],
             "box1__other": ["test", "", ""],
         }
     )
@@ -27,7 +27,7 @@ def test_collapse_checkbox_columns():
 def test_split_cases_and_contacts():
     df = pd.DataFrame(
         {
-            "record_id": [1, 2, 2, 3, 3],
+            "record_id": ["1", "2", "2", "3", "3"],
             "redcap_repeat_instrument": [
                 None,
                 None,
@@ -35,31 +35,34 @@ def test_split_cases_and_contacts():
                 np.nan,
                 "close_contacts",
             ],
-            "redcap_repeat_instance": pd.array([None, None, 1, None, 1], dtype="Int64"),
+            "redcap_repeat_instance": [None, None, "1", None, "1"],
             # Int64 (capital I) is the nullable integer type:
             # https://pandas.pydata.org/pandas-docs/stable/user_guide/integer_na.html
-            "cdms_id": pd.array([1234, 1234, None, 1234, None], dtype="Int64"),
-            "arbitrary": ["some", "arbitrary", "values", 2, "test"],
+            "cdms_id": ["1234", "1234", None, "1234", None],
+            "arbitrary": ["some", "arbitrary", "values", "2", "test"],
             "empty_col": [None, None, None, np.nan, np.nan],
         },
         index=[1, 2, 3, 4, 5],
     )
     expected_cases_df = pd.DataFrame(
         {
-            "record_id": [1, 2, 3],
-            "cdms_id": pd.array([1234, 1234, 1234], dtype="Int64"),
-            "arbitrary": ["some", "arbitrary", 2],
-            "external_id": pd.array([1234, 1234, 1234], dtype="Int64"),
+            "record_id": ["1", "2", "3"],
+            "cdms_id": ["1234", "1234", "1234"],
+            "arbitrary": ["some", "arbitrary", "2"],
+            "external_id": ["1234", "1234", "1234"],
         },
         index=[1, 2, 4],
     )
     expected_contacts_df = pd.DataFrame(
         {
-            "record_id": [2, 3],
+            "record_id": ["2", "3"],
             "arbitrary": ["values", "test"],
             "parent_type": ["patient", "patient"],
-            "parent_external_id": [1234, 1234],
-            "external_id": ["REDCAP-2-1", "REDCAP-3-1"],
+            "parent_external_id": ["1234", "1234"],
+            "external_id": [
+                "1234:redcap_repeat_instance:1",
+                "1234:redcap_repeat_instance:1",
+            ],
         },
         index=[3, 5],
     )
@@ -73,7 +76,7 @@ def test_split_cases_and_contacts():
 def test_split_cases_and_contacts_no_cdms_id():
     df = pd.DataFrame(
         {
-            "record_id": [1, 2, 2, 3, 3],
+            "record_id": ["1", "2", "2", "3", "3"],
             "redcap_repeat_instrument": [
                 None,
                 None,
@@ -81,29 +84,36 @@ def test_split_cases_and_contacts_no_cdms_id():
                 np.nan,
                 "close_contacts",
             ],
-            "redcap_repeat_instance": pd.array([None, None, 1, None, 1], dtype="Int64"),
+            "redcap_repeat_instance": [None, None, "1", None, "1"],
             # cdms_id missing
-            "arbitrary": ["some", "arbitrary", "values", 2, "test"],
+            "arbitrary": ["some", "arbitrary", "values", "2", "test"],
             "empty_col": [None, None, None, np.nan, np.nan],
         },
         index=[1, 2, 3, 4, 5],
     )
     expected_cases_df = pd.DataFrame(
         {
-            "record_id": [1, 2, 3],
+            "record_id": ["1", "2", "3"],
             # cdms_id missing
-            "arbitrary": ["some", "arbitrary", 2],
-            "external_id": ["REDCAP-1", "REDCAP-2", "REDCAP-3"],
+            "arbitrary": ["some", "arbitrary", "2"],
+            "external_id": [
+                "REDCAP:record_id:1",
+                "REDCAP:record_id:2",
+                "REDCAP:record_id:3",
+            ],
         },
         index=[1, 2, 4],
     )
     expected_contacts_df = pd.DataFrame(
         {
-            "record_id": [2, 3],
+            "record_id": ["2", "3"],
             "arbitrary": ["values", "test"],
             "parent_type": ["patient", "patient"],
-            "parent_external_id": ["REDCAP-2", "REDCAP-3"],
-            "external_id": ["REDCAP-2-1", "REDCAP-3-1"],
+            "parent_external_id": ["REDCAP:record_id:2", "REDCAP:record_id:3"],
+            "external_id": [
+                "REDCAP:record_id:2:redcap_repeat_instance:1",
+                "REDCAP:record_id:3:redcap_repeat_instance:1",
+            ],
         },
         index=[3, 5],
     )


### PR DESCRIPTION
Sample run:

```
$ sync-redcap-to-commcare --state-file=redcap_test.yaml --username=$COMMCARE_USERNAME --apikey=$COMMCARE_API_KEY --project=philly-covid19-intqa --redcap-api-url=$REDCAP_API_URL --redcap-api-key=$REDCAP_API_KEY --sync-all
2020-11-02 20:57:15,531 - main - INFO - Retrieving and cleaning data from REDCap...
Using REDCap record_id for external_id! Future uploads may duplicate cases.
2020-11-02 20:57:15,799 - main - INFO - Uploading found patients (case) to CommCare...
2020-11-02 20:57:16,061 - main - INFO - Sleeping 2 seconds and checking upload status...
2020-11-02 20:57:18,237 - main - INFO - Succesfully uploaded. All done.
2020-11-02 20:57:18,237 - main - INFO - Uploading found contacts to CommCare...
2020-11-02 20:57:18,503 - main - INFO - Sleeping 2 seconds and checking upload status...
2020-11-02 20:57:20,787 - main - INFO - Succesfully uploaded. All done.
```

To do:

- [ ] Exclude contacts (or leave as-is since presumably there won't be any anyways?)
- [ ] Test again after REDCap form is updated
- [x] Ask the client to review the created cases in IntQA
- [x] Make `cdms_id` column (and others?) configurable (maybe in a subsequent PR?)