### PR TITLE
Make it easier to deal with re-uploaded, post validation annotated bulk upload requests

### DIFF
--- a/cc_utilities/command_line/bulk_upload_legacy_contact_data.py
+++ b/cc_utilities/command_line/bulk_upload_legacy_contact_data.py
@@ -165,7 +165,9 @@ def main_with_args(
         right_index=True,
     )
     logger.info(f"Generating validation report at {validation_report_path}")
-    report_df.to_excel(validation_report_path, index=False)
+    report_df.to_excel(
+        validation_report_path, index=False, sheet_name=WB_CONTACT_SHEET_NAME
+    )
     num_invalid = len(case_data_df[~case_data_df["is_valid"]])
     if not case_data_df["is_valid"].all() and reject_all_if_any_invalid_rows:
         msg = (
@@ -255,7 +257,7 @@ def main_with_args(
     final_report_path = PurePath(reporting_path).joinpath(final_report_name)
     final_df.drop(["contact_id"], inplace=True, axis=1)
     logger.info(f"Generating a final report at {final_report_path}")
-    final_df.to_excel(final_report_path, index=False)
+    final_df.to_excel(final_report_path, index=False, sheet_name=WB_CONTACT_SHEET_NAME)
     logger.info("I am quite done now.")
 
 

--- a/cc_utilities/command_line/user_friendly_bulk_contact_upload.py
+++ b/cc_utilities/command_line/user_friendly_bulk_contact_upload.py
@@ -57,18 +57,19 @@ def main():
         project_slug, required_vars["PROJECT_AGENCY_OWNER_LOOKUP_PATH"]
     )
 
-    drop_columns = os.environ.get("DROP_COLUMNS")
-    if drop_columns:
-        drop_columns = drop_columns.split(",")
+    drop_columns_after = os.environ.get("DROP_COLUMNS_AFTER")
+    if drop_columns_after:
         logger.info(
-            f"Altering original workbook, dropping columns: {', '.join(drop_columns)}"
+            f"Altering original workbook, dropping columns after colum "
+            f"{drop_columns_after}"
         )
         # open the Excel workbook and delete the columns then save it
         path = pathlib.Path(file_path).expanduser()
         wb = load_workbook(path)
         ws = wb[WB_CONTACT_SHEET_NAME]
-        for col in drop_columns:
-            ws.delete_cols(column_index_from_string(col), 1)
+        # we drop from after the drop_columns_after index to fifty columns across
+        # just to give more than comfortable buffer
+        ws.delete_cols(column_index_from_string(drop_columns_after) + 1, 50)
         wb.save(path)
 
     rename_columns_json_path = os.environ.get("RENAME_COLUMNS_JSON_PATH")


### PR DESCRIPTION
- Names the worksheet in 'contacts' in Excel reports
- Deletes columns _after_ a reference column, instead of deleting a specific list of delete columns


**NOTE**: For the script to work after merging these changes, a new env var needs to be set:

```
export DROP_COLUMNS_AFTER="L"
```

Additionally, `DROP_COLUMNS` is no longer required