### PR TITLE
[DIS-1547.2] a few updates to the REDCap sync

### DIFF
--- a/cc_utilities/legacy_upload.py
+++ b/cc_utilities/legacy_upload.py
@@ -422,7 +422,7 @@ def normalize_phone_number(raw_value, col_name=None, country_code="US"):
     return (
         f"{number.country_code}{number.national_number}"
         if col_name == "contact_phone_number"
-        else number.national_number
+        else str(number.national_number)
     )
 
 

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -2,7 +2,11 @@ import numpy as np
 import pandas as pd
 import pytest
 
-from cc_utilities.redcap_sync import collapse_checkbox_columns, split_cases_and_contacts
+from cc_utilities.redcap_sync import (
+    collapse_checkbox_columns,
+    normalize_phone_cols,
+    split_cases_and_contacts,
+)
 
 
 def test_collapse_checkbox_columns():
@@ -12,6 +16,7 @@ def test_collapse_checkbox_columns():
             "box1___green": [None, "1", "1"],
             "box1___blue": [None, "0", None],
             "box1___other": ["1", None, "0"],
+            "box2___red": ["0", "0", "0"],
             "box1__other": ["test", "", ""],
         }
     )
@@ -19,9 +24,27 @@ def test_collapse_checkbox_columns():
         {
             "box1__other": ["test", "", ""],
             "box1": ["yellow other", "green", "yellow green"],
+            "box2": [None, None, None],
         }
     )
     output_df = collapse_checkbox_columns(input_df)
+    pd.testing.assert_frame_equal(expected_output_df, output_df)
+
+
+def test_normalize_phone_cols():
+    input_df = pd.DataFrame(
+        {
+            "phone1": ["(919) 555-1212", "9195551213", "919-555-1214"],
+            "phone2": ["(919) 555-1215", "9195551216", "919-555-1217"],
+        }
+    )
+    expected_output_df = pd.DataFrame(
+        {
+            "phone1": ["9195551212", "9195551213", "9195551214"],
+            "phone2": ["(919) 555-1215", "9195551216", "919-555-1217"],
+        }
+    )
+    output_df = normalize_phone_cols(input_df, ["phone1"])
     pd.testing.assert_frame_equal(expected_output_df, output_df)
 
 
@@ -77,3 +100,34 @@ def test_split_cases_and_contacts():
 def test_split_cases_and_contacts_no_cdms_id():
     with pytest.raises(ValueError):
         split_cases_and_contacts(pd.DataFrame({}), external_id_col="cdms_id")
+
+
+def test_split_cases_and_contacts_no_contacts():
+    input_df = pd.DataFrame(
+        {
+            "record_id": ["1", "2", "3"],
+            "redcap_repeat_instrument": pd.Series([None, None, np.nan], dtype="object"),
+            "redcap_repeat_instance": pd.Series([None, None, None], dtype="object"),
+            "cdms_id": ["1234", "1234", "1234"],
+            "arbitrary": ["some", "arbitrary", "2"],
+            "empty_col": pd.Series([None, None, np.nan], dtype="object"),
+        },
+        index=[1, 2, 3],
+    )
+    expected_output_cases_df = pd.DataFrame(
+        {
+            "record_id": ["1", "2", "3"],
+            "cdms_id": ["1234", "1234", "1234"],
+            "arbitrary": ["some", "arbitrary", "2"],
+            "external_id": ["1234", "1234", "1234"],
+        },
+        index=[1, 2, 3],
+    )
+    expected_output_contacts_df = pd.DataFrame(
+        {}, index=pd.Int64Index([], dtype="int64"),
+    )
+    cases_output_df, contacts_output_df = split_cases_and_contacts(
+        input_df, external_id_col="cdms_id"
+    )
+    pd.testing.assert_frame_equal(expected_output_cases_df, cases_output_df)
+    pd.testing.assert_frame_equal(expected_output_contacts_df, contacts_output_df)


### PR DESCRIPTION
* Support normalizing phone columns and make sure `normalize_phone_number()` always returns a string
* Don't create new cases by default (might want to customize this in the future)
* Disable contact sync for now (will want to customize this too)
* Don't create empty (`""`) checkbox columns; filter them out instead
* Pandas raises strange errors when running `apply()` on a DataFrame with no rows, so try to avoid doing that
