### PR TITLE
Handle empty phone values

### DIFF
--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -94,10 +94,6 @@ def main_with_args(
                 # to floats and adding unnecessary decimal points in the data when
                 # uploaded to CommCare.
                 "dtype": str,
-                # If field is not present, it might not be converted to an empty string
-                # unless we use this setting:
-                # https://stackoverflow.com/a/43832955/347942
-                "keep_default_na": False,
             },
         )
         if len(redcap_records.index) == 0:

--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -94,6 +94,10 @@ def main_with_args(
                 # to floats and adding unnecessary decimal points in the data when
                 # uploaded to CommCare.
                 "dtype": str,
+                # If field is not present, it might not be converted to an empty string
+                # unless we use this setting:
+                # https://stackoverflow.com/a/43832955/347942
+                "keep_default_na": False,
             },
         )
         if len(redcap_records.index) == 0:
@@ -182,7 +186,7 @@ def main():
         args.redcap_api_url,
         args.redcap_api_key,
         args.external_id_col,
-        args.phone_cols,
+        args.phone_cols or [],
         args.state_file,
         args.sync_all,
     )

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -71,8 +71,11 @@ def normalize_phone_cols(df, phone_cols):
     """
     df = df.copy()
     for col_name in phone_cols:
-        df[col_name] = df[col_name].apply(
-            partial(normalize_phone_number, col_name=col_name)
+        # replace N/A values with empty string before normalizing
+        df[col_name] = (
+            df[col_name]
+            .fillna("")
+            .apply(partial(normalize_phone_number, col_name=col_name))
         )
     return df
 

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "SQLAlchemy",
         "phonenumbers",
         "pandas",
+        "pyyaml",
         "pycap==1.1.2",  # REDCap API
         "numpy==1.19.3",  # windows env chokes on > than this version
         "xlrd",

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -38,7 +38,7 @@ def test_normalize_phone_cols():
             "phone2": ["(919) 555-1215", "9195551216", float("nan")],
         }
     )
-    # request cols are normalized and with N/A converted to empty strings
+    # phone1 col is normalized and with N/A converted to empty string
     expected_output_df = pd.DataFrame(
         {
             "phone1": ["9195551212", "9195551213", ""],

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -34,14 +34,15 @@ def test_collapse_checkbox_columns():
 def test_normalize_phone_cols():
     input_df = pd.DataFrame(
         {
-            "phone1": ["(919) 555-1212", "9195551213", "919-555-1214"],
-            "phone2": ["(919) 555-1215", "9195551216", "919-555-1217"],
+            "phone1": ["(919) 555-1212", "9195551213", float("nan")],
+            "phone2": ["(919) 555-1215", "9195551216", float("nan")],
         }
     )
+    # request cols are normalized and with N/A converted to empty strings
     expected_output_df = pd.DataFrame(
         {
-            "phone1": ["9195551212", "9195551213", "9195551214"],
-            "phone2": ["(919) 555-1215", "9195551216", "919-555-1217"],
+            "phone1": ["9195551212", "9195551213", ""],
+            "phone2": ["(919) 555-1215", "9195551216", float("nan")],
         }
     )
     output_df = normalize_phone_cols(input_df, ["phone1"])


### PR DESCRIPTION
When parsing a CSV, it seems that pandas will import it as the `dtype` that you specify unless it is empty, in which case it uses the default `na_values` parsing.

Found here: https://stackoverflow.com/a/43832955/347942
Docs: https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.read_csv.html#pandas-read-csv (scroll down to `keep_default_na`):

> If keep_default_na is False, and na_values are not specified, no strings will be parsed as NaN.

UPDATE: OK, that didn't work because it converted all `null` values to empty string and we use the value of `null` in some places (like when trying to find contact rows). So the 2nd commit now only converts N/A to empty strings right at the time we are processing the phone columns.