### PR TITLE
pre-commit workflow to package install deps

### DIFF
--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -3,7 +3,7 @@ name: package dependencies
 on:
   push:
     branches:
-      - package-deps
+      - main
 
 jobs:
   package-deps:

--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -1,0 +1,35 @@
+name: package dependencies
+
+on:
+  push:
+    branches:
+      - package-deps
+
+jobs:
+  package-deps:
+    strategy:
+      matrix:
+        os:
+          - windows-2019
+          - ubuntu-20.04
+          - macos-11.0
+        python-version: [3.7]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install .
+          mkdir ${{ matrix.os }}-deps/
+          cd ${{ matrix.os }}-deps/
+          pip freeze | grep -v commcare-utilities > requirements.txt
+          pip download -r requirements.txt
+      - uses: actions/upload-artifact@v2
+        with:
+          name: commcare-utilities-${{ matrix.os }}-deps
+          path: ${{ matrix.os }}-deps/


### PR DESCRIPTION
I needed a way to download all the dependencies for a platform I don't readily have access to.

This could be revised in the future to cut a release of the code itself + dependencies for each app via https://github.com/actions/create-release.

![Screen Shot 2020-11-20 at 10 50 14 AM](https://user-images.githubusercontent.com/160132/99820002-34378880-2b1e-11eb-9154-494aa36a90d4.png)
