### PR TITLE
use same retry logic for commcare status checks as we use for uploads

### DIFF
--- a/cc_utilities/common.py
+++ b/cc_utilities/common.py
@@ -200,9 +200,7 @@ def upload_data_to_commcare(
         seconds = 2
         logger.info(f"Sleeping {seconds} seconds and checking upload status...")
         time.sleep(seconds)
-        response_ = session.get(
-            response.json()["status_url"], headers=headers, timeout=request_timeout
-        )
+        response_ = session.get(response.json()["status_url"])
 
         if response_.json()["state"] == COMMCARE_UPLOAD_STATES["failed"]:
             msg = (


### PR DESCRIPTION
Fix for this:
<img width="960" alt="Screen Shot 2020-12-09 at 10 18 29 AM" src="https://user-images.githubusercontent.com/160132/101650153-a27ab700-3a09-11eb-96d6-39968a1a6926.png">
