### PR TITLE
Auto-publish releases with dependencies packaged when a tag is pushed

### DIFF
--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -71,7 +71,7 @@ jobs:
       - name: Get Upload URL
         id: get_release_info
         run: |
-          echo ::set-output name=upload_url::$(cat release_url/release_url.txt)
+          echo "::set-output name=upload_url::$(cat release_url/release_url.txt)"
       - name: Upload Release Asset
         uses: actions/upload-release-asset@v1
         env:

--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -4,9 +4,39 @@ on:
   push:
     branches:
       - main
+      - package-release
 
 jobs:
+  # Split release/upload workflow adapted from:
+  # https://github.com/actions/create-release/issues/14#issuecomment-555379810
+  release:
+    name: Create GitHub Release
+    # TODO: Possibly only publish tagged releases
+    # if: contains(github.ref, 'tags/v')
+    runs-on: ubuntu-latest
+    steps:
+    - name: Create Release
+      id: create_release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        draft: false
+        prerelease: false
+    # Save release_url for package-deps job
+    - name: Output Release URL File
+      run: echo "${{ steps.create_release.outputs.upload_url }}" > release_url.txt
+    - name: Save Release URL File for publish
+      uses: actions/upload-artifact@v1
+      with:
+        name: release_url
+        path: release_url.txt
   package-deps:
+    # TODO: Possibly only publish tagged releases
+    # if: contains(github.ref, 'tags/v')
+    needs: [release]
     strategy:
       matrix:
         os:
@@ -29,7 +59,26 @@ jobs:
           cd ${{ matrix.os }}-deps/
           pip freeze | grep -v commcare-utilities > requirements.txt
           pip download -r requirements.txt
+          cd ..
+          zip -r ${{ matrix.os }}-deps.zip ${{ matrix.os }}-deps/
       - uses: actions/upload-artifact@v2
         with:
           name: commcare-utilities-${{ matrix.os }}-deps
           path: ${{ matrix.os }}-deps/
+      - name: Load Release URL File from release job
+        uses: actions/download-artifact@v1
+        with:
+          name: release_url
+      - name: Get Upload URL
+        id: get_release_info
+        run: |
+          echo ::set-output name=upload_url::$(cat release_url/release_url.txt)
+      - name: Upload Release Asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.get_release_info.outputs.upload_url }}
+          asset_path: ${{ matrix.os }}-deps.zip
+          asset_name: ${{ matrix.os }}-deps.zip
+          asset_content_type: application/zip

--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -57,11 +57,11 @@ jobs:
           pip freeze | grep -v commcare-utilities > requirements.txt
           pip download -r requirements.txt
       - name: Zip dependencies
-        if: '!contains(matrix.os, "windows")'
+        if: "!contains(matrix.os, 'windows')"
         run: |
           zip -r ${{ matrix.os }}-deps.zip ${{ matrix.os }}-deps/
       - name: Zip dependencies
-        if: 'contains(matrix.os, "windows")'
+        if: contains(matrix.os, 'windows')
         run: |
           powershell Compress-Archive ${{ matrix.os }}-deps/ ${{ matrix.os }}-deps.zip
       - name: Load Release URL File from release job

--- a/.github/workflows/package-deps.yml
+++ b/.github/workflows/package-deps.yml
@@ -2,17 +2,15 @@ name: package dependencies
 
 on:
   push:
-    branches:
-      - main
-      - package-release
+    # Sequence of patterns matched against refs/tags
+    tags:
+    - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
 
 jobs:
   # Split release/upload workflow adapted from:
   # https://github.com/actions/create-release/issues/14#issuecomment-555379810
   release:
     name: Create GitHub Release
-    # TODO: Possibly only publish tagged releases
-    # if: contains(github.ref, 'tags/v')
     runs-on: ubuntu-latest
     steps:
     - name: Create Release
@@ -34,8 +32,7 @@ jobs:
         name: release_url
         path: release_url.txt
   package-deps:
-    # TODO: Possibly only publish tagged releases
-    # if: contains(github.ref, 'tags/v')
+    name: Package and upload dependencies
     needs: [release]
     strategy:
       matrix:
@@ -59,12 +56,14 @@ jobs:
           cd ${{ matrix.os }}-deps/
           pip freeze | grep -v commcare-utilities > requirements.txt
           pip download -r requirements.txt
-          cd ..
+      - name: Zip dependencies
+        if: '!contains(matrix.os, "windows")'
+        run: |
           zip -r ${{ matrix.os }}-deps.zip ${{ matrix.os }}-deps/
-      - uses: actions/upload-artifact@v2
-        with:
-          name: commcare-utilities-${{ matrix.os }}-deps
-          path: ${{ matrix.os }}-deps/
+      - name: Zip dependencies
+        if: 'contains(matrix.os, "windows")'
+        run: |
+          powershell Compress-Archive ${{ matrix.os }}-deps/ ${{ matrix.os }}-deps.zip
       - name: Load Release URL File from release job
         uses: actions/download-artifact@v1
         with:

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push]
 
 jobs:
-  build-ubuntu:
+  test-ubuntu:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -3,7 +3,7 @@ name: Test
 on: [push]
 
 jobs:
-  test-ubuntu:
+  build-ubuntu:
     runs-on: ubuntu-latest
     strategy:
       max-parallel: 4

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ git tag v1.0
 git push origin v1.0
 ```
 
-Once the tag is pushed, it'll take a few minutes for the dependencies to be packaged and uploaded as additional release assets. You can watch the "Actions" tab above for updates.
+Once the tag is pushed, it'll take a few minutes for the dependencies to be packaged and uploaded as additional release assets. You can watch the "Actions" tab for the project in GitHub for updates.
 
 ## Scripts
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ To run tests, from root of repo, do:
 tox
 ```
 
+## Releases
+
+This repo contains a workflow to auto-publish releases, with OS-specific dependencies packaged, when a tag is pushed. So, to create a release, simply create and push a new tag:
+
+```bash
+git tag v1.0
+git push origin v1.0
+```
+
+Once the tag is pushed, it'll take a few minutes for the dependencies to be packaged and uploaded as additional release assets. You can watch the "Actions" tab above for updates.
+
 ## Scripts
 
 ### `sync-commcare-app-to-db`

--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,7 @@ setup(
         "SQLAlchemy",
         "phonenumbers",
         "pandas",
+        "pyodbc",
         "pyyaml",
         "pycap==1.1.2",  # REDCap API
         "numpy==1.19.3",  # windows env chokes on > than this version


### PR DESCRIPTION
Build artifacts were hard to find and seem to disappear, so let's persist dependencies a little better with a release. These may be handy when installing these scripts on servers without internet and when the OS differs from your local OS. Not sure why the Mac ones aren't updating... I assume their Mac workers are backed up or something...

<img width="495" alt="Screen Shot 2020-12-21 at 8 22 00 PM" src="https://user-images.githubusercontent.com/160132/102837640-36655f00-43ca-11eb-8d17-7a325426ccff.png">

I also added `pyodbc` to install_requires to make sure it's included; we could add it in another way (manual pip install?) if that creates issues for other installs of this script.