### PR TITLE
pin commcare-export==1.5.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     license="MIT",
     packages=["cc_utilities", "cc_utilities.command_line"],
     install_requires=[
-        "commcare-export>=1.4.0",
+        "commcare-export==1.5.0",
         "retry",
         "dateparser",
         "openpyxl==2.5.12",  # commcare-export is pinned to this version


### PR DESCRIPTION
This release contains the fix for partial syncing (https://github.com/dimagi/commcare-export/pull/159).

I'd also like to pin this to a specific version in case they do introduce a breaking change.