### PR TITLE
Fix "closed" status of stub patients in bulk contact upload script

### DIFF
--- a/cc_utilities/legacy_upload.py
+++ b/cc_utilities/legacy_upload.py
@@ -216,6 +216,8 @@ def generate_cc_dummy_patient_cases(
     upload_data_to_commcare(
         dummies_data, project_slug, "patient", "case_id", cc_user_name, cc_api_key
     )
+    # retrieve the dummies by contact id so we can get their case_ids, which we
+    # will attach to contacts we later upload
     cc_dummy_patients = []
     for ext_id in external_ids:
         cc_dummy_patients.extend(

--- a/cc_utilities/legacy_upload.py
+++ b/cc_utilities/legacy_upload.py
@@ -193,6 +193,7 @@ def create_dummy_patient_case_data(external_id):
         "stub": "yes",
         "name": "(no index case)",
         "stub_type": "contact_without_index",
+        "current_status": "closed",
     }
 
 
@@ -215,24 +216,6 @@ def generate_cc_dummy_patient_cases(
     upload_data_to_commcare(
         dummies_data, project_slug, "patient", "case_id", cc_user_name, cc_api_key
     )
-    # Because of an oddity of the CommCare API, even if cases are created with
-    # `close: "yes"`, the cases will appear as open in the case list dashboard.
-    # We therefore send `close_data` below to close them
-    close_data = [
-        dict(external_id=item["external_id"], close="yes") for item in dummies_data
-    ]
-    upload_data_to_commcare(
-        close_data,
-        project_slug,
-        "patient",
-        "external_id",
-        cc_user_name,
-        cc_api_key,
-        search_field="external_id",
-        create_new_cases="off",
-    )
-    # retrieve the dummies by contact id so we can get their case_ids, which we
-    # will attach to contacts we later upload
     cc_dummy_patients = []
     for ext_id in external_ids:
         cc_dummy_patients.extend(

--- a/tests/test_legacy_contact_upload.py
+++ b/tests/test_legacy_contact_upload.py
@@ -115,6 +115,7 @@ def test_create_dummy_patient_case_data():
         "stub": "yes",
         "name": "(no index case)",
         "stub_type": "contact_without_index",
+        "current_status": "closed",
     }
     actual = create_dummy_patient_case_data(external_id)
     assert set(expectations.keys()) == set(actual.keys())


### PR DESCRIPTION
We learned that stub patients should not have `"close" = "yes"` set, but instead should have `"current_status" = "closed"`, otherwise they will be inaccessible in Commcare (even though they will indeed be uploaded).

This PR makes the required change and updates a test effected by the change.