### PR TITLE
Closes #60 case investigator reject

### DIFF
--- a/cc_utilities/command_line/sync_redcap_to_commcare.py
+++ b/cc_utilities/command_line/sync_redcap_to_commcare.py
@@ -12,6 +12,7 @@ from cc_utilities.redcap_sync import (
     collapse_housing_fields,
     handle_cdms_matching,
     normalize_phone_cols,
+    reject_records_already_filled_out_by_case_investigator,
     set_external_id_column,
     split_complete_and_incomplete_records,
     update_successful_records_in_redcap,
@@ -121,6 +122,15 @@ def main_with_args(
                 .pipe(normalize_phone_cols, phone_cols)
                 .pipe(collapse_housing_fields)
                 .pipe(set_external_id_column, external_id_col)
+                .pipe(
+                    reject_records_already_filled_out_by_case_investigator,
+                    external_id_col,
+                    commcare_project_name,
+                    commcare_user_name,
+                    commcare_api_key,
+                    redcap_api_url,
+                    redcap_api_key,
+                )
                 .pipe(
                     handle_cdms_matching,
                     db_url,

--- a/cc_utilities/constants.py
+++ b/cc_utilities/constants.py
@@ -55,6 +55,14 @@ COMMCARE_DEFAULT_HIDDEN_FIELD_MAPPINGS = {
     ("user_id", "user_id"),
 }
 
+INTERVIEW_DISPOSITION = "interview_disposition"
+ACCEPTED_INTERVIEW_DISPOSITION_VALUES = [
+    "no_attempt",
+    "voicemail_sms",
+    "no_voicemail",
+    "invalid_phone_number",
+    "attempted_4_days",
+]
 # For bulk contact upload, these values should be added to each contact, where key
 # is the column name, and val is the row val for that column
 COMMCARE_DEFAULT_CONTACT_KEY_VALUES = {

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -312,6 +312,9 @@ def get_commcare_cases_with_acceptable_interview_dispositions(
     accepted_external_ids = []
     external_ids = df[external_id_col].to_list()
     for ext_id in external_ids:
+        # Get cases in CommCare to compare interview_disposition.
+        # Querying CDMS would be a favorable source of truth for this, but did
+        # not seem to have this column available at the time of implementing this.
         cases = get_commcare_cases_by_external_id_with_backoff(
             project_slug, cc_user_name, cc_api_key, external_id=ext_id
         )

--- a/notebooks/.ipynb_checkpoints/sync_redcap_to_commcare-checkpoint.ipynb
+++ b/notebooks/.ipynb_checkpoints/sync_redcap_to_commcare-checkpoint.ipynb
@@ -46,8 +46,8 @@
     "redcap_api_url = os.getenv(\"REDCAP_API_URL\")\n",
     "redcap_api_key = os.getenv(\"REDCAP_API_KEY\")\n",
     "commcare_api_key = os.getenv(\"COMMCARE_API_KEY\")\n",
-    "commcare_user_name = os.getenv(\"COMMCARE_USERNAME\")\n",
-    "commcare_project_name = os.getenv(\"COMMCARE_PROJECT\")\n",
+    "commcare_user_name = os.getenv(\"COMMCARE_USER_NAME\")\n",
+    "commcare_project_name = os.getenv(\"COMMCARE_PROJECT_NAME\")\n",
     "database_url = os.getenv(\"DB_URL\")\n",
     "\n",
     "state_file = \"redcap_test.yaml\"\n",
@@ -332,13 +332,63 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reject records already filled out by a case investigator.\n"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n"
+    "from cc_utilities.legacy_upload import get_commcare_cases_by_external_id_with_backoff\n",
+    "from cc_utilities.common import get_commcare_cases"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = redcap_records.dropna(subset=[\"cdms_id\"])\n",
+    "external_ids = df[\"cdms_id\"].to_list()\n",
+    "external_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commcare_cases = []\n",
+    "for ext_id in external_ids:\n",
+    "    commcare_cases.extend(\n",
+    "        get_commcare_cases(\n",
+    "            commcare_project_name, commcare_user_name, commcare_api_key, external_id=ext_id\n",
+    "        )\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commcare_cases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/notebooks/sync_redcap_to_commcare.ipynb
+++ b/notebooks/sync_redcap_to_commcare.ipynb
@@ -46,8 +46,8 @@
     "redcap_api_url = os.getenv(\"REDCAP_API_URL\")\n",
     "redcap_api_key = os.getenv(\"REDCAP_API_KEY\")\n",
     "commcare_api_key = os.getenv(\"COMMCARE_API_KEY\")\n",
-    "commcare_user_name = os.getenv(\"COMMCARE_USERNAME\")\n",
-    "commcare_project_name = os.getenv(\"COMMCARE_PROJECT\")\n",
+    "commcare_user_name = os.getenv(\"COMMCARE_USER_NAME\")\n",
+    "commcare_project_name = os.getenv(\"COMMCARE_PROJECT_NAME\")\n",
     "database_url = os.getenv(\"DB_URL\")\n",
     "\n",
     "state_file = \"redcap_test.yaml\"\n",
@@ -304,9 +304,21 @@
    },
    "outputs": [],
    "source": [
-    "# upload_complete_records(\n",
-    "#     cases_df, commcare_api_key, commcare_project_name, commcare_user_name\n",
-    "# )"
+    "upload_complete_records(\n",
+    "    complete_records, commcare_api_key, commcare_project_name, commcare_user_name\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# TODO: Remove me\n",
+    "incomplete_records[\"interview_disposition\"] = \"attempted_4_days\"\n",
+    "incomplete_records = incomplete_records.loc[:1]\n",
+    "incomplete_records"
    ]
   },
   {
@@ -319,16 +331,23 @@
    },
    "outputs": [],
    "source": [
-    "# upload_incomplete_records(\n",
-    "#     cases_df, commcare_api_key, commcare_project_name, commcare_user_name\n",
-    "# )\n",
+    "upload_incomplete_records(\n",
+    "    incomplete_records, commcare_api_key, commcare_project_name, commcare_user_name\n",
+    ")\n",
     "\n",
-    "for index, row in incomplete_records.iterrows():\n",
-    "    # Drops any values in this Series with missing/NA values,\n",
-    "    # and converts it back to a DataFrame.\n",
-    "    data = row.dropna().to_frame().transpose()\n",
+    "# for index, row in incomplete_records.iterrows():\n",
+    "#     # Drops any values in this Series with missing/NA values,\n",
+    "#     # and converts it back to a DataFrame.\n",
+    "#     data = row.dropna().to_frame().transpose()\n",
     "\n",
-    "data"
+    "# data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Reject records already filled out by a case investigator.\n"
    ]
   },
   {
@@ -337,8 +356,66 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "\n"
+    "from cc_utilities.legacy_upload import get_commcare_cases_by_external_id_with_backoff\n",
+    "from cc_utilities.common import get_commcare_cases, CommCareUtilitiesError"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "df = redcap_records.dropna(subset=[\"cdms_id\"])\n",
+    "external_ids = df[\"cdms_id\"].to_list()\n",
+    "external_ids"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commcare_cases = []\n",
+    "for ext_id in external_ids:\n",
+    "    print(commcare_project_name, commcare_user_name, commcare_api_key, ext_id)\n",
+    "    try:\n",
+    "        commcare_cases.extend(\n",
+    "            get_commcare_cases(\n",
+    "                commcare_project_name, commcare_user_name, commcare_api_key, external_id=ext_id\n",
+    "            )\n",
+    "        )\n",
+    "    except CommCareUtilitiesError:\n",
+    "        print(f\"Error, skipping...\")\n",
+    "        continue"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "commcare_cases[0][\"properties\"][\"interview_disposition\"]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "props = [{cc[\"properties\"][\"cdms_id\"]: cc[\"properties\"].get(\"interview_disposition\")} for cc in commcare_cases]\n",
+    "props"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {

--- a/tests/test_legacy_contact_upload.py
+++ b/tests/test_legacy_contact_upload.py
@@ -362,7 +362,7 @@ def mock_get_commcare_cases(monkeypatch):
     def mock(*args, **kwargs):
         return MockCommCareFunctions.get_commcare_cases(*args, **kwargs)
 
-    monkeypatch.setattr("cc_utilities.legacy_upload.get_commcare_cases", mock)
+    monkeypatch.setattr("cc_utilities.common.get_commcare_cases", mock)
 
 
 @pytest.fixture


### PR DESCRIPTION


- [ ] This is currently based on `58-match-patients-dob` and should not be merged until that's done being reviewed
- [x] Self-review - look for leftover comments / things that could be tidied up
- [x] Do more extensive and thorough end-to-end testing with more fake data. 

### Testing:

I messed around with different `interview_disposition` values via pandas/jupyter notebook (adding interview_dispositions to cases and sending them to commcare) and then running the script to make sure they were rejected and accepted as expected. 
Note that it's also very handy to look at the 'Logging' in REDCap under 'applications' in the project, where you can see the integration_status updates on records after syncing. 
