### PR TITLE
Refs #74: Skip syncing records to CommCare where the external_id is not found

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 venv
+.direnv/
 .env
 .envrc
 .vscode

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -6,10 +6,7 @@ import pandas as pd
 import redcap
 from sqlalchemy import MetaData, Table, create_engine, select
 
-from .common import (
-    get_commcare_cases_by_external_id_with_backoff,
-    upload_data_to_commcare,
-)
+from .common import get_commcare_cases, upload_data_to_commcare
 from .constants import (
     ACCEPTED_INTERVIEW_DISPOSITION_VALUES,
     DOB_FIELD,
@@ -352,7 +349,10 @@ def get_commcare_cases_with_acceptable_interview_dispositions(
         # Get cases in CommCare to compare interview_disposition. Querying
         # the SQL mirror would be a favorable source of truth for this, but did
         # not seem to have this column available at the time of implementing this.
-        cases = get_commcare_cases_by_external_id_with_backoff(
+        # In the event no case is found in CommCare, it will NOT be allowed to sync
+        # since presumably this would create a new record rather than update an
+        # existing one anyways.
+        cases = get_commcare_cases(
             project_slug, cc_user_name, cc_api_key, external_id=ext_id
         )
         if cases:
@@ -392,7 +392,7 @@ def reject_records_already_filled_out_by_case_investigator(
         reject_records = add_integration_status_columns(
             reject_records,
             status=REDCAP_REJECTED_PERSON,
-            reason="Case already submitted by a Case Investigator.",
+            reason="Case not found or already submitted by a Case Investigator.",
         )
         import_records_to_redcap(reject_records, redcap_api_url, redcap_api_key)
     logger.info("Done.")

--- a/cc_utilities/redcap_sync.py
+++ b/cc_utilities/redcap_sync.py
@@ -360,6 +360,8 @@ def get_commcare_cases_with_acceptable_interview_dispositions(
             interview_disposition = case_properties.get(INTERVIEW_DISPOSITION)
             if interview_disposition in ACCEPTED_INTERVIEW_DISPOSITION_VALUES:
                 accepted_external_ids.append(ext_id)
+        else:
+            logger.warning(f"external_id {ext_id} not found in CommCare")
     return accepted_external_ids
 
 

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -472,15 +472,12 @@ def test_get_commcare_cases_with_acceptable_interview_dispositions():
     ]
     expected_accepted_external_ids = ["1111"]
     with patch(
-        "cc_utilities.redcap_sync.get_commcare_cases_by_external_id_with_backoff",
-        side_effect=case_mocks,
-    ) as mock_get_commcare_cases_by_external_id_with_backoff:
+        "cc_utilities.redcap_sync.get_commcare_cases", side_effect=case_mocks,
+    ) as mock_get_commcare_cases:
         accepted_external_ids = get_commcare_cases_with_acceptable_interview_dispositions(
             input_df, "cdms_id", "test_key", "test_user_name", "test_project"
         )
-    assert mock_get_commcare_cases_by_external_id_with_backoff.call_count == len(
-        input_df
-    )
+    assert mock_get_commcare_cases.call_count == len(input_df)
     assert accepted_external_ids == expected_accepted_external_ids
 
 
@@ -497,7 +494,7 @@ def test_reject_records_already_filled_out_by_case_investigator():
     )
 
     timestamp = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    reason = "Case already submitted by a Case Investigator."
+    reason = "Case not found or already submitted by a Case Investigator."
     expected_reject_records = pd.DataFrame(
         {
             "record_id": ["3", "4"],

--- a/tests/test_redcap_sync.py
+++ b/tests/test_redcap_sync.py
@@ -467,7 +467,7 @@ def test_get_commcare_cases_with_acceptable_interview_dispositions():
             }
         ],
         [{"properties": {"interview_disposition": "unacceptable"}}],
-        None,
+        [],  # get_commcare_cases returns empty list if not found
         [{"properties": {"other": ""}}],
     ]
     expected_accepted_external_ids = ["1111"]


### PR DESCRIPTION
Fixes #74 

- This switches to `get_commcare_cases` instead of `get_commcare_cases_by_external_id_with_backoff`, which should return an empty list instead of raising an exception if no case was found.
- I think the `_with_backoff` version was intended for instances when the case was just created, and CommCare may not have processed it right away. For our purposes, I think we can trust that the case will exist in CommCare (if it's ever going to exist) since we only hit this code after someone has received and responded to the SMS.
- I did not go through the trouble of trying to differentiate the rejected reason, so I'll ask the client if that's okay before merging.